### PR TITLE
Remove callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ the API usage, however it differs in the ways below:
 - **Gearbox does not use a GenServer as a backing process**.
   Since GenServer can be a potential bottleneck in a system, for that reason I think it's best
   to leave process management to users of the library.
-- `before_transition/3` and `after_transition/3` exposes the `current_state` and also `next_state`,
-  providing more options when defining callbacks.
+- **No before/after callbacks**. Callback allow you to add side effects, but side effects violate
+  Single Responsibility Principle, and that can bring surprises to your codebase
+  (e.g: "How come everytime this transition happens, X happens?"). Gearbox nudges you to keep domain-logic
+  callbacks close to your contexts/domain events. Gearbox still ships with a `guard_transition/3` callback,
+  as that is intrinsic to state machines.
 - Gearbox does not ship with a `Phoenix Dashboard` view.
   A really cool and great concept, but more often than not it is not needed and the added dependency
   can prove more trouble than worth.
 
-For a more detailed documentation, checkout the HexDoc - [https://hexdocs.pm/gearbox](https://hexdocs.pm/gearbox).
+For a more detailed documentation, checkout the [Gearbox's HexDoc](https://hexdocs.pm/gearbox).
 
 ## Installation
 
@@ -32,6 +35,33 @@ def deps do
   [
     {:gearbox, "~> 0.1.0"}
   ]
+end
+```
+
+## Usage
+
+Gearbox's main API is `Gearbox.transition/3`. There's a `bang!` variant available too.
+
+### Example
+
+`Gearbox.transitions(%Order{}, PaymentMachine, "paid")`
+
+- **First Argument** - an Elixir map, can be a struct or a non-struct.
+- **Second Argument** - a State Machine, read on to find out how to create a state machine.
+- **Third Argument** - the desired next state.
+
+Here's how to create a state machine:
+
+```elixir
+defmodule PaymentMachine do
+  use Gearbox,
+    field: :status, # used to retrieve the state of the given struct. Defaults to `:state`
+    states: ~w(pending_payment paid refunded), # list of finite states in the state machine
+    initial: "pending_payment", # initial state of the struct, if struct has `nil` state to begin with. Defaults to the first item of `:states`
+    transitions: %{
+      "pending_payment" => "paid",
+      "paid" => "refunded",
+    } # a map of possible transitions from `current_state` to `next_state`. `*` wildcard is allowed to indicate any states.
 end
 ```
 
@@ -50,9 +80,18 @@ you are better off to use an `Agent`/`GenServer` where you have better control o
 business logics.
 
 As of now, Gearbox does not provide a way to create `events/actions` in a state machine.
-This is because Gearbox is not a domain/context wrapper, I feel events/actions
-that can trigger a state change should reside closer to your contexts, therefore I urge
-users to group these events as domain events (contexts), rather than state machine events.
+This is because Gearbox is not a domain/context wrapper, Events and actions that can
+trigger a state change should reside closer to your contexts, therefore I urge users to
+group these events as domain events (contexts), rather than state machine events.
+
+Gearbox previously shipped with `before_transition/3` and `after_transition/3` in `0.1.0`,
+but after some discussions I have decided to take a deliberate decision to **remove** callbacks.
+This is because callbacks by nature, allow you to add side effects, but side effects violate
+**Single Responsibility Principle**, and callbacks can often bring unintended surprises
+to your codebase (e.g: "How come everytime this transition happens, X happens?").
+
+Therefore, Gearbox nudges you to keep domain/business-logic callbacks close to your contexts/domain events.
+Gearbox still ships with a `guard_transition/3` callback, as that is intrinsic to state machines.
 
 ## Features
 Below lists a couple of features that Gearbox currently have.
@@ -85,22 +124,15 @@ defmodule Commerce do
 end
 ```
 
-### Callbacks (Before & After)
-Callbacks provide you hooks to execute `before` and `after` a transition happens/happened.
-
-- `before_transition/3`
-- `after_transition/3`
-
-> **Note** that callbacks should always return `struct`, and callbacks will only be run if transition is valid.
-
 ### Guard Transitions
 Guard transitions enforces a condition to be passed before a transitions is committed.
 
 A transition is halted if the function returns `{:halt, reason}`, it continues otherwise.
-It will then return `{:error, reason}` for `Gearbox.transition/3`
+The reason giving in `{:halt, reason}` will then propagate up to `Gearbox.transition/3`
+as `{:error, reason}`.
 
 ```elixir
-# You can match on both `from` and `to` states.
+# You can add condition check on both `from` and `to` states.
 def guard_transition(struct, _from, _to) do
   case :rand.uniform() do
     val when val >= 0.5 ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Gearbox.MixProject do
   def project do
     [
       app: :gearbox,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/gearbox_test.exs
+++ b/test/gearbox_test.exs
@@ -69,6 +69,23 @@ defmodule GearboxTest do
     purge(GearboxMachine)
   end
 
+  test "transition/3 works for non-structs" do
+    gear = %{state: "neutral"}
+
+    defmodule GearboxMachine do
+      use Gearbox,
+        states: ~w(neutral drive),
+        transitions: %{
+          "neutral" => "drive"
+        }
+    end
+
+    assert {:ok, gear} = Gearbox.transition(gear, GearboxMachine, "drive")
+    assert gear.state == "drive"
+  after
+    purge(GearboxMachine)
+  end
+
   test "transition/3 allows valid transition (not in list)" do
     gear = %Gear{state: "neutral"}
 
@@ -103,7 +120,7 @@ defmodule GearboxTest do
     purge(GearboxMachine)
   end
 
-  test "transition/3 should allow wildcard neutral" do
+  test "transition/3 should allow wildcard input" do
     gear = %Gear{state: "neutral"}
 
     defmodule GearboxMachine do
@@ -120,7 +137,7 @@ defmodule GearboxTest do
     purge(GearboxMachine)
   end
 
-  test "transition/3 should allow wildcard driveination" do
+  test "transition/3 should allow wildcard destination" do
     gear = %Gear{state: "neutral"}
 
     defmodule GearboxMachine do
@@ -177,7 +194,7 @@ defmodule GearboxTest do
     purge(GearboxMachine)
   end
 
-  test "transition/3 disallow invalid transition (gearndefined neutral)" do
+  test "transition/3 disallow invalid transition (undefined input)" do
     gear = %Gear{state: "undefined"}
 
     defmodule GearboxMachine do
@@ -244,58 +261,6 @@ defmodule GearboxTest do
     assert_raise Gearbox.InvalidTransitionError, ~r/Cannot transition from/, fn ->
       Gearbox.transition!(gear, GearboxMachine, "invalid")
     end
-  after
-    purge(GearboxMachine)
-  end
-
-  test "before_transition/2 should allow override" do
-    gear = %Gear{state: "neutral"}
-
-    defmodule GearboxMachine do
-      use Gearbox,
-        states: ~w(neutral drive),
-        transitions: %{
-          "neutral" => ~w(drive)
-        }
-
-      def before_transition(struct, "neutral", "drive") do
-        struct =
-          struct
-          |> Map.put(:name, "jellybean")
-
-        struct
-      end
-    end
-
-    assert gear.name == nil
-    assert {:ok, gear} = Gearbox.transition(gear, GearboxMachine, "drive")
-    assert gear.name == "jellybean"
-  after
-    purge(GearboxMachine)
-  end
-
-  test "after_transition/2 should allow override" do
-    gear = %Gear{state: "neutral"}
-
-    defmodule GearboxMachine do
-      use Gearbox,
-        states: ~w(neutral drive),
-        transitions: %{
-          "neutral" => ~w(drive)
-        }
-
-      def after_transition(struct, "neutral", "drive") do
-        struct =
-          struct
-          |> Map.put(:name, "jellybean")
-
-        struct
-      end
-    end
-
-    assert gear.name == nil
-    assert {:ok, gear} = Gearbox.transition(gear, GearboxMachine, "drive")
-    assert gear.name == "jellybean"
   after
     purge(GearboxMachine)
   end


### PR DESCRIPTION
As of now, Gearbox ships with `before_transition/3` and
`after_transition/3`, which are callbacks/hooks that you can run, before
and after a transition.

However, after some discussions I have decided to take a deliberate
decision to **remove** callbacks. This is because callbacks by nature
allow you to add side effects, but side effects violate **Single
Responsibility Principle**, and callbacks can often bring unintended
surprises to your codebase (e.g: "How come everytime this transition
happens, X happens?").

By removing callbacks, Gearbox nudges you to keep your domain logics
closer to your contexts where they make sense, instead of hidden inside
the state machine.

---

This commit also bumps Gearbox to `0.2.0`