### PR TITLE
Use elixir 1.8.2 as a base elixir version.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Gearbox.MixProject do
     [
       app: :gearbox,
       version: "0.2.0",
-      elixir: "~> 1.9",
+      elixir: "~> 1.8.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Hi, 

I see that the current gearbox implementation is using elixir 1.9 as a base version. 
I think we should lower this base version, due to much of elixir deployed projects are based on a version lower than 1.9.

I have tested the implementation with 1.8.2, So I would like to send a pull request that set the base version to 1.8.2

I also think this base version could be lower than 1.8.2 also.