### PR TITLE
Fix error when using atom key for destination

### DIFF
--- a/lib/gearbox.ex
+++ b/lib/gearbox.ex
@@ -220,8 +220,9 @@ defmodule Gearbox do
     end)
   end
 
-  @spec cast_destination(dest :: list() | String.t(), states :: list(state())) :: list()
+  @spec cast_destination(dest :: list() | String.t() | atom(), states :: list(state())) :: list()
   defp cast_destination(@wildcard, states), do: states
   defp cast_destination(dest, _states) when is_list(dest), do: dest
   defp cast_destination(dest, _states) when is_binary(dest), do: [dest]
+  defp cast_destination(dest, _states) when is_atom(dest), do: [dest]
 end

--- a/test/gearbox_test.exs
+++ b/test/gearbox_test.exs
@@ -137,6 +137,23 @@ defmodule GearboxTest do
     purge(GearboxMachine)
   end
 
+  test "transition/3 should allow atoms" do
+    gear = %Gear{state: :neutral}
+
+    defmodule GearboxMachine do
+      use Gearbox,
+        states: ~w(neutral drive)a,
+        transitions: %{
+          neutral: :drive
+        }
+    end
+
+    assert {:ok, gear} = Gearbox.transition(gear, GearboxMachine, :drive)
+    assert gear.state == :drive
+  after
+    purge(GearboxMachine)
+  end
+
   test "transition/3 should allow wildcard destination" do
     gear = %Gear{state: "neutral"}
 


### PR DESCRIPTION
The error is failing with `Gearbox.cast_destination/2` because the guard
clauses permits only `list` and `string`, so when the destination is an
`:atom` key, things fall through.

This commit adds a new clause to explicitly allow atom keys for
destinations.