### PR TITLE
Bump README to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Get the latest version from [Hex](https://hex.pm/packages/gearbox)
 ```elixir
 def deps do
   [
-    {:gearbox, "~> 0.2.1"}
+    {:gearbox, "~> 0.3.1"}
   ]
 end
 ```


### PR DESCRIPTION
Version 0.3.0 and above have support for the Ecto module which has a dedicated section in the README.