### PR TITLE
Allow transitioning a changeset

### DIFF
--- a/lib/gearbox.ex
+++ b/lib/gearbox.ex
@@ -209,6 +209,8 @@ defmodule Gearbox do
   @spec validate_transition(struct :: struct | map, machine :: any, next_state :: state()) ::
           {:ok, any} | {:error, String.t()}
   def validate_transition(struct, machine, next_state) do
+    struct = maybe_apply_changeset_changes(struct)
+
     field = machine.__machine_field__
     states = machine.__machine_states__
     initial_state = machine.__machine_states__(:initial)
@@ -231,6 +233,11 @@ defmodule Gearbox do
         {:error, reason}
     end
   end
+
+  defp maybe_apply_changeset_changes(%Ecto.Changeset{} = changeset),
+    do: Ecto.Changeset.apply_changes(changeset)
+
+  defp maybe_apply_changeset_changes(struct), do: struct
 
   @spec get_possible_transitions(candidates :: map(), states :: list(state())) :: list()
   defp get_possible_transitions(candidates, states) do

--- a/lib/gearbox.ex
+++ b/lib/gearbox.ex
@@ -209,8 +209,6 @@ defmodule Gearbox do
   @spec validate_transition(struct :: struct | map, machine :: any, next_state :: state()) ::
           {:ok, any} | {:error, String.t()}
   def validate_transition(struct, machine, next_state) do
-    struct = maybe_apply_changeset_changes(struct)
-
     field = machine.__machine_field__
     states = machine.__machine_states__
     initial_state = machine.__machine_states__(:initial)
@@ -233,11 +231,6 @@ defmodule Gearbox do
         {:error, reason}
     end
   end
-
-  defp maybe_apply_changeset_changes(%Ecto.Changeset{} = changeset),
-    do: Ecto.Changeset.apply_changes(changeset)
-
-  defp maybe_apply_changeset_changes(struct), do: struct
 
   @spec get_possible_transitions(candidates :: map(), states :: list(state())) :: list()
   defp get_possible_transitions(candidates, states) do

--- a/lib/gearbox/ecto.ex
+++ b/lib/gearbox/ecto.ex
@@ -18,6 +18,8 @@ if Code.ensure_loaded?(Ecto) do
     @spec transition_changeset(struct :: struct, machine :: any, next_state :: Gearbox.state()) ::
             {:ok, struct | map} | {:error, String.t()}
     def transition_changeset(struct, machine, next_state) do
+      struct = maybe_apply_changeset_changes(struct)
+
       case validate_transition(struct, machine, next_state) do
         {:ok, nil} ->
           changeset = Ecto.Changeset.change(struct, %{machine.__machine_field__ => next_state})
@@ -33,5 +35,10 @@ if Code.ensure_loaded?(Ecto) do
           {:error, error_changeset}
       end
     end
+
+    defp maybe_apply_changeset_changes(%Ecto.Changeset{} = changeset),
+      do: Ecto.Changeset.apply_changes(changeset)
+
+    defp maybe_apply_changeset_changes(struct), do: struct
   end
 end

--- a/test/gearbox_ecto_test.exs
+++ b/test/gearbox_ecto_test.exs
@@ -100,7 +100,6 @@ defmodule GearboxTest.Ecto do
     purge(GearboxMachine)
   end
 
-  @tag :only
   test "transition_changeset/3 should return a valid Ecto changeset when passed another changeset" do
     gear = %GearSchema{state: "neutral"}
 


### PR DESCRIPTION
Ecto changesets should be composable, the following should work:

```
schema
|> change(%{})
|> Gearbox.Ecto.transition_changeset(...)
```

Right now, if a changeset is passed to `Gearbox.Ecto.transition_changeset`, it is not going to fetch a correct `current_state`. Currently, `Gearbox.Ecto.transition_changeset` will only work if it is the first call in a pipe:

```
schema
|> Gearbox.Ecto.transition_changeset(...)
|> change(%{})
```

The problem comes from `validate_transition` not handling changesets properly. Here's what happens when a changeset is passed:

```
struct = %Ecto.Changeset{
  action: nil,
  changes: %{state: "drive"},
  errors: [],
  data: #GearboxTest.Ecto.GearSchema<>,
  valid?: true
}

  def validate_transition(struct, machine, next_state) do
        # will attempt to grab `state` field from the changeset, which will always cause it to default to `initial_state`
        current_state = Map.get(struct, field) || initial_state
  end
```

This PR fixes this problem by ensuring that whenever a changeset is used, its changes are applied first, before grabbing the `current_state`.