### PR TITLE
fix: maybe_apply_changeset_changes in Gearbox.Ecto overriding the original struct changes in transition_changeset

### DIFF
--- a/lib/gearbox/ecto.ex
+++ b/lib/gearbox/ecto.ex
@@ -18,9 +18,9 @@ if Code.ensure_loaded?(Ecto) do
     @spec transition_changeset(struct :: struct, machine :: any, next_state :: Gearbox.state()) ::
             {:ok, struct | map} | {:error, String.t()}
     def transition_changeset(struct, machine, next_state) do
-      struct = maybe_apply_changeset_changes(struct)
+      validation_struct = maybe_apply_changeset_changes(struct)
 
-      case validate_transition(struct, machine, next_state) do
+      case validate_transition(validation_struct, machine, next_state) do
         {:ok, nil} ->
           changeset = Ecto.Changeset.change(struct, %{machine.__machine_field__ => next_state})
           {:ok, changeset}

--- a/test/gearbox_ecto_test.exs
+++ b/test/gearbox_ecto_test.exs
@@ -112,14 +112,14 @@ defmodule GearboxTest.Ecto do
         }
     end
 
-    assert {:ok, %Ecto.Changeset{} = gear_changeset} =
-             Gearbox.Ecto.transition_changeset(gear, GearboxMachine, "drive")
+    changeset = Ecto.Changeset.change(gear, %{name: "Cybertruck", state: "drive"})
 
     assert {:ok, %Ecto.Changeset{} = gear_changeset} =
-             Gearbox.Ecto.transition_changeset(gear_changeset, GearboxMachine, "next")
+             Gearbox.Ecto.transition_changeset(changeset, GearboxMachine, "next")
 
     assert gear_changeset.valid?
     assert Ecto.Changeset.get_change(gear_changeset, :state) == "next"
+    assert Ecto.Changeset.get_change(gear_changeset, :name) == "Cybertruck"
   after
     purge(GearboxMachine)
   end


### PR DESCRIPTION
This PR fixes an issue that I've inadvertently introduced in my previous PR: https://github.com/edisonywh/gearbox/pull/12

The culprit was this line, which overrode any previous changeset `changes` by applying them:
```
struct = maybe_apply_changeset_changes(struct)
```

This is a problem whenever using this function with Ecto - this will leave the `changes` empty, and any previous changes made before `Gearbox.Ecto` will not get applied by Ecto when running `Repo.update`.

The fix is to only use the struct with applied changes within the `validate_transition` function only.