### PR TITLE
Fix typespec for error case

### DIFF
--- a/lib/gearbox/ecto.ex
+++ b/lib/gearbox/ecto.ex
@@ -16,7 +16,7 @@ if Code.ensure_loaded?(Ecto) do
       - `{:error, error_changeset}` with an error populated if transition cannot be made.
     """
     @spec transition_changeset(struct :: struct, machine :: any, next_state :: Gearbox.state()) ::
-            {:ok, struct | map} | {:error, String.t()}
+            {:ok, struct | map} | {:error, Ecto.Changeset.t()}
     def transition_changeset(struct, machine, next_state) do
       validation_struct = maybe_apply_changeset_changes(struct)
 


### PR DESCRIPTION
The current typespec for `Gearbox.Ecto.transition_changeset/3` incorrectly identifies the potential return values as `{:ok, struct | map} | {:error, String.t()}`, where the code clearly returns `{:ok, struct | map} | {:error, Ecto.Changeset.t()}`.  This causes dialyzer to flag this as a violation of the contract.  

This PR is a small change to correct this problem.
