### PR TITLE
Use parens on function calls

### DIFF
--- a/lib/gearbox.ex
+++ b/lib/gearbox.ex
@@ -190,7 +190,7 @@ defmodule Gearbox do
   def transition(struct, machine, next_state) do
     case validate_transition(struct, machine, next_state) do
       {:ok, nil} ->
-        struct = Map.put(struct, machine.__machine_field__, next_state)
+        struct = Map.put(struct, machine.__machine_field__(), next_state)
         {:ok, struct}
 
       {:error, reason} ->
@@ -209,11 +209,11 @@ defmodule Gearbox do
   @spec validate_transition(struct :: struct | map, machine :: any, next_state :: state()) ::
           {:ok, any} | {:error, String.t()}
   def validate_transition(struct, machine, next_state) do
-    field = machine.__machine_field__
-    states = machine.__machine_states__
+    field = machine.__machine_field__()
+    states = machine.__machine_states__()
     initial_state = machine.__machine_states__(:initial)
     current_state = Map.get(struct, field) || initial_state
-    transitions = machine.__machine_transitions__
+    transitions = machine.__machine_transitions__()
 
     with candidates <- Map.take(transitions, [current_state, @wildcard]),
          possible_transitions = get_possible_transitions(candidates, states),

--- a/lib/gearbox/ecto.ex
+++ b/lib/gearbox/ecto.ex
@@ -22,7 +22,7 @@ if Code.ensure_loaded?(Ecto) do
 
       case validate_transition(validation_struct, machine, next_state) do
         {:ok, nil} ->
-          changeset = Ecto.Changeset.change(struct, %{machine.__machine_field__ => next_state})
+          changeset = Ecto.Changeset.change(struct, %{machine.__machine_field__() => next_state})
           {:ok, changeset}
 
         {:error, reason} ->
@@ -30,7 +30,7 @@ if Code.ensure_loaded?(Ecto) do
             struct
             |> struct()
             |> Ecto.Changeset.change()
-            |> Ecto.Changeset.add_error(machine.__machine_field__, reason)
+            |> Ecto.Changeset.add_error(machine.__machine_field__(), reason)
 
           {:error, error_changeset}
       end


### PR DESCRIPTION
Removes warnings due to Elixir 1.17

<img width="1728" alt="Screenshot 2024-09-19 at 9 11 07 AM" src="https://github.com/user-attachments/assets/5807473d-7fed-4ac1-a954-55472097b3fb">
